### PR TITLE
Add generated anaconda.yaml

### DIFF
--- a/anaconda.yaml
+++ b/anaconda.yaml
@@ -3,4 +3,4 @@ upstream_sources:
   - github:
       identifier: HEASARC/cfitsio
       use_max_tag: true
-      strip_prefix: cfitsio-
+      prefix: cfitsio-


### PR DESCRIPTION
This PR adds generated `anaconda.yaml` (Feedstock Configuration Format).